### PR TITLE
fix: checkout trustify by commit digest or PR number

### DIFF
--- a/Containerfile.trustify
+++ b/Containerfile.trustify
@@ -15,6 +15,8 @@ RUN ["bash", "-c", "\
     git clone https://github.com/trustification/trustify ; \
     if [[ -n \"$rev\" ]]; then \
         cd trustify ; \
+        git config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/*" ; \
+        git fetch origin ; \
         git checkout \"$rev\" ; \
     fi \
 "]


### PR DESCRIPTION
With this "pure git" change, the checkout can happen using the PR number which helps the integration with the `issue_comment` event on PR because it brings in the PR number.